### PR TITLE
Add new error keyword to repeater

### DIFF
--- a/src/coffee/repeater-task-queue.coffee
+++ b/src/coffee/repeater-task-queue.coffee
@@ -26,6 +26,7 @@ retryKeywords = [
   'write EPIPE'
   'connect ECONNRESET'
   'Timed out while waiting for handshake'
+  'HttpError: aborted'
 ]
 
 # Public: A `RepeaterTaskQueue` adds request repeater on particular response errors

--- a/src/spec/repeater-task-queue.spec.coffee
+++ b/src/spec/repeater-task-queue.spec.coffee
@@ -108,6 +108,7 @@ describe 'RepeaterTaskQueue', ->
       'write EPIPE'
       'connect ECONNRESET'
       'Timed out while waiting for handshake'
+      'HttpError: aborted'
     ]
     task = new RepeaterTaskQueue {}, {}
     expect(_.isEqual(task.repeaterOptions.retryKeywords, retryKeywords)).toEqual true


### PR DESCRIPTION
#### Summary
On the error `HttpError: aborted` the sdk should repeat.